### PR TITLE
Boost.StaticAssertの翻訳ドキュメントを移植

### DIFF
--- a/archive/boost_docs/document/int_const_guidelines.md
+++ b/archive/boost_docs/document/int_const_guidelines.md
@@ -1,0 +1,243 @@
+# Coding Guidelines for Integral Constant Expressions
+
+汎整数定数式は C++ の多くの場面で用いられる。配列のサイズや、bit-field (※訳語データベースへ？) 、列挙値の初期化や、型でないテンプレートパラメータ (※訳語データベースへ？) の引数として。しかしながら多くのコンパイラは汎整数定数式の扱いに問題を抱えている。つまりこの結果として、特に型でないテンプレートパラメータを使ったプログラミングは、困難に満ちたものになりうる。そしてしばしば、特定のコンパイラでは型でないテンプレートパラメータはサポートされていない、という間違った推論に陥いらせる。この短い記事は、これに従えば、汎整数定数式を Boost に正しくサポートされている全てのコンパイラでポータブルな作法で用いることができるようになるガイドラインと回避方法を提供するようにデザインされている。この記事は主に Boost ライブラリの作者に向けられたものであるが、何故 Boost のコードがそのような方法で書かれているのかを理解することや、自身でポータブルなコードを書くことを欲するユーザにとっても役に立つものであろう。
+
+## 汎整数定数式とは何か？
+
+汎整数定数式は標準のセクション 5.19 で述べられている。そしてしばしば「コンパイル時定数」と呼ばれる。汎整数定数式は下記のいずれかになりうる:
+
+1. 汎整数定数、例えば `0u` や `3L`。
+2. 列挙の値。
+3. グローバルな汎整数定数、例えば:
+```cpp
+const int my_INTEGRAL_CONSTANT = 3;
+```
+4. 静的メンバの定数、例えば:
+```cpp
+struct myclass
+{ static const int value = 0; };
+```
+5. メンバの列挙の値、例えば:
+```cpp
+struct myclass
+{ enum{ value = 0 }; };
+```
+6. 整数型や列挙型の型でないテンプレートパラメータ。
+7. `sizeof` 式の結果、例えば:
+```cpp
+sizeof(foo(a, b, c))
+```
+8. 対象の型が整数型か列挙型で、かつ引数がその他の汎整数定数式のいずれかであるか浮動小数定数である場合の `static_cast` の結果。
+9. 二つの汎整数定数式に二項演算子を適用した結果:
+
+    `INTEGRAL_CONSTANT1 op INTEGRAL_CONSTANT2`
+
+    演算子が除算演算子やコンマ演算子で無い場合に提供される。
+
+10. 汎整数定数式に単項演算子を適用した結果:
+
+    `op INTEGRAL_CONSTANT1`
+
+    演算子がインクリメントやデクリメント演算子で無い場合に提供される。
+
+## コーディングガイドライン
+
+以下のガイドラインは特別な順番で並んでいるわけではない (言い換えれば、申し訳無いが、あなたはこれら全てに従う必要があるということだ)。そして不完全でもあるかもしれない、コンパイラの変更やさらなる問題との遭遇のために、さらにガイドラインが加わるかもしれない。
+
+### クラスメンバの定数を宣言するときは必ず `BOOST_STATIC_CONSTANT` マクロを使う。
+
+```cpp
+template <class T>
+struct myclass
+{
+   BOOST_STATIC_CONSTANT(int, value = sizeof(T));
+};
+```
+
+Rationale: メンバ定数のインライン初期化をサポートしていないコンパイラもある。メンバの列挙をうまく扱えないコンパイラもある (それらは必ずしも汎整数定数式として扱わない)。`BOOST_STATIC_CONSTANT` マクロは問題のコンパイラで最も適切な方法を使用する。
+
+### `int` より大きな型の汎整数定数式を宣言しない。
+
+Rationale: 理論上は全ての汎整数型を汎整数定数式の中で使用できるが、実際問題として、大くのコンパイラは汎整数定数式を `int` より大きくない型に制限する。
+
+### 論理演算子を汎整数定数式に対して使わない。代わりにテンプレートメタプログラミングを使う。
+
+&lt;boost/type_traits/ice.hpp&gt; ヘッダはたくさんの回避方法のテンプレートを含んでいる。それは論理演算子の役割りを成し遂げる。例えば以下のように書く代わりに:
+
+```cpp
+INTEGRAL_CONSTANT1 || INTEGRAL_CONSTANT2
+```
+
+以下を使いなさい:
+
+```cpp
+::boost::type_traits::ice_or<INTEGRAL_CONSTANT1,INTEGRAL_CONSTANT2>::value
+```
+
+Rationale: 多くのコンパイラ(特に Borland と Microsoft のコンパイラ)は論理演算子を含む汎整数定数式を真の汎整数定数式として認識しない傾向がある。この問題は通常、汎整数定数式がテンプレートのコードの内部の奥深くにあって、複写して診断することが難しい場合にのみ現れる。
+
+### 型でないテンプレート引数として使われる汎整数定数式の中でいかなる演算子も使うな。
+
+以下よりも:
+
+```cpp
+typedef myclass<INTEGRAL_CONSTANT1 == INTEGRAL_CONSTANT2> mytypedef;
+```
+
+以下を使いなさい:
+
+```cpp
+typedef myclass< some_symbol> mytypedef;
+```
+
+ただし、`some_symbol` はその値が `(INTEGRAL_CONSTANT1 == INTEGRAL_CONSTANT2)` となる汎整数定数式に与えられた名前である。
+
+Rationale: 古い EDG ベースのコンパイラ (それがそのプラットフォームで最新のバージョンである場合もある。) は、演算子を含む式を型でないテンプレートパラメータであると認識しない。たとえそのような式が汎整数定数式としてどこか他の場所で使うことができるとしても。
+
+### 汎整数定数式を参照するために、常に完全に修飾された名前を使いなさい。
+
+例えば:
+
+```cpp
+typedef myclass< ::boost::is_integral<some_type>::value> mytypedef;
+```
+
+Rationale: 少なくとも一つのコンパイラ (Borland のもの) は名前が完全に修飾されていなければ (完全に修飾されているとは、`::` で始まっていることを指す)、汎整数定数式の名前を認識しない。
+
+### '`<`' と '`::`' の間には常に空白を入れなさい。
+
+例えば:
+
+```cpp
+typedef myclass< ::boost::is_integral<some_type>::value> mytypedef;
+                ^
+                ここにスペースがあることを確認しなさい!
+```
+
+Rationale: `<:` はそれ自身で合法的な二重字であって、それゆえ`<::` は `[:` と同様に解釈される。
+
+### 汎整数定数式としてローカルな名前を使うな。
+
+Example:
+
+```cpp
+template <class T>
+struct foobar
+{
+   BOOST_STATIC_CONSTANT(int, temp = computed_value);
+   typedef myclass<temp> mytypedef;  // error
+};
+```
+
+Rationale: 少なくとも一つのコンパイラ (Borland のもの) はこれを受け入れない。
+
+しかしながら、以下を使うことによってこれを修正することができる:
+
+```cpp
+template <class T>
+struct foobar
+{
+   BOOST_STATIC_CONSTANT(int, temp = computed_value);
+   typedef foobar self_type;
+   typedef myclass<(self_type::temp)> mytypedef;  // OK
+};
+```
+
+これは少なくとも一つのコンパイラ (VC6) で通らない。汎整数定数式を別の特性クラスに移す方がより良い。
+
+```cpp
+template <class T>
+struct foobar_helper
+{
+   BOOST_STATIC_CONSTANT(int, temp = computed_value);
+};
+
+template <class T>
+struct foobar
+{
+   typedef myclass< ::foobar_helper<T>::value> mytypedef;  // OK
+};
+```
+
+### 型で無いテンプレートパラメータのために他に依存する値を使うな。
+
+例えば:
+
+```cpp
+template <class T, int I = ::boost::is_integral<T>::value>  // Error can't deduce value of I in some cases.
+struct foobar;
+```
+
+Rationale: この種の使い方は Borland C++ で失敗する。これはデフォルト値が前のテンプレートパラメータに依存している場合のみの問題であることに注意しなさい。例えば、以下は問題無い:
+
+```cpp
+template <class T, int I = 3>  // OK, default value is not dependent
+struct foobar;
+```
+
+## 未解決の問題
+
+以下の問題は解決していないか、コンパイラ毎の解決があるか、一つ以上のコーディングガイドラインを破るかのどれかである。
+
+### numeric_limits に気をつけなさい
+
+ここには三つの問題がある:
+
+1. &lt;limits&gt; ヘッダが無いかもしれない。&lt;limits&gt; を決して 直接インクルードせず、代わりに &lt;boost/pending/limits.hpp&gt; を使うことが推奨される。このヘッダはもしそれがあるなら、『本当の』 &lt;limits&gt; ヘッダをインクルードする。もし無ければ自身の std::numeric_limits の定義を提供する。Boost は &lt;limits&gt; ヘッダが無ければ、BOOST_NO_LIMITS マクロも定義する。
+2. std::numeric_limits の実装はその静的定数メンバが汎整数定数式として使うことができない方法で定義されるかもしれない。これは非標準であるが、少なくとも二つの標準ライブラリベンダに影響するバグであるようだ。Boost はこの場合、&lt;boost/config.hpp&gt; の中で BOOST_NO_LIMITS_COMPILE_TIME_CONSTANTS を定義する。
+3. VC6 には std::numeric_limits のメンバがテンプレートのコードの中 で『早まって評価』されうるという奇妙なバグがある。例えば:
+
+```cpp
+template <class T>
+struct limits_test
+{
+   BOOST_STATIC_ASSERT(::std::numeric_limits<T>::is_specialized);
+};
+```
+
+このコードはたとえテンプレートがインスタンス化されなくても VC6 でコンパイルに失敗する。いくつかの奇怪な理由のために `::std::numeric_limits<T>::is_specialized` はテンプレートパラメータ T が何であろうと常に偽と評価される。この問題は `std::numeric_limits` に依存する式に限定されるようである: 例えば、もし `::std::numeric_limits<T>::is_specialized` を `::boost::is_arithmetic<T>::value` に置換すれば、全てうまくいく。以下の回避方法もうまく働くが、コーディングガイドラインに抵触する:
+
+```cpp
+template <class T>
+struct limits_test
+{
+   BOOST_STATIC_CONSTANT(bool, check = ::std::numeric_limits<T>::is_specialized);
+   BOOST_STATIC_ASSERT(check);
+};
+```
+
+だから、以下のようなものが多分最上の手段である:
+
+```cpp
+template <class T>
+struct limits_test
+{
+#ifdef BOOST_MSVC
+   BOOST_STATIC_CONSTANT(bool, check = ::std::numeric_limits<T>::is_specialized);
+   BOOST_STATIC_ASSERT(check);
+#else
+   BOOST_STATIC_ASSERT(::std::numeric_limits<T>::is_specialized);
+#endif
+};
+```
+
+### `sizeof` 演算子の使い方に気をつけなさい。
+
+私の知る限り、全てのコンパイラはその引数が型の名前 (やテンプレートの識別子) である場合 `sizeof` 式を正しく扱うようだ。しかしながら以下のような場合問題が起こりうる:
+
+1. 引数がメンバ変数やローカル変数の名前である場合 (コードは VC6 ではコンパイルされないだろう)。
+2. 引数が一時変数の生成を含む式である場合 (コードは Borland C++ でコンパイルされないだろう)。
+3. 引数がオーバーロードされた関数呼出しを含む場合 (コードは Metroworks C++ ではコンパイルされるが、結果は間違った値になる)。
+
+### 必要無ければ `boost::is_convertible` を使うな
+
+`is_convertible` は `sizeof` 演算子を用いて実装されているので、Metroworks のコンパイラと使う場合は常に間違った値を返し、Borland のコンパイラではコンパイルされないかもしれない。(テンプレート引数が使われるかどうかに依る)。
+
+---
+
+Copyright Dr John Maddock 2001, all rights reserved.
+
+---
+Japanese Translation Copyright (C) 2003 shinichiro.h &lt;g940455@mail.ecc.u-tokyo.ac.jp&gt;.
+
+オリジナルの、及びこの著作権表示が全ての複製の中に現れる限り、この文書の複製、利用、変更、販売そして配布を認める。このドキュメントは「あるがまま」に提供されており、いかなる明示的、暗黙的保証も行わない。また、いかなる目的に対しても、その利用が適していることを関知しない。

--- a/archive/boost_docs/libs/static_assert/static_assert.md
+++ b/archive/boost_docs/libs/static_assert/static_assert.md
@@ -1,0 +1,145 @@
+# §ヘッダファイル（Header） &lt;[boost/static_assert.hpp](http://www.boost.org/doc/libs/1_31_0/boost/static_assert.hpp)&gt;
+
+ヘッダファイル &lt;boost/static_assert.hpp&gt;はマクロ、BOOST_STATIC_ASSERT(x) を提供する。 BOOST_STATIC_ASSERT(x) は[汎整数定数式](../../document/int_const_guidelines.md) *x* を評価した結果、偽であるならばコンパイル時エラーメッセージを生成する。 つまり、コンパイル時に、assert マクロと同等の働きをするものである。 これは、「コンパイル時アサート（compile-time-assertion）」という名で知られているものであるが、このドキュメントでは「静的アサート（static assertion）」と記述することとする。 条件が真である時、このマクロはいかなるコードやデーターを生成しないことに注意すること。加えて、このマクロは namespace もしくは、クラス、もしくは、関数のスコープ内で利用される事にも注意すること。 このマクロがテンプレート内で利用されているばあいは、テンプレートより実体が生成される時に診断が実行される。 これは、特にテンプレート・パラメータを確認することに役立つ。
+
+BOOST_STATIC_ASSERTの狙いのうちの1つは、可読性の高いエラー・メッセージを生成することである。 これらは、ユーザーにサポート外の方法でライブラリを利用しようとしたことを直接的に示す。 エラーメッセージがコンパイラ間で明らかに異なっていても、あなたは少なくとも、
+
+```
+Illegal use of COMPILE_TIME_ASSERTION_FAILURE<false>
+```
+
+これに似た記述を見ることになるだろう。
+
+それは、少なからず目立つはずである。
+
+あなたは、[クラス](#class)、[関数](#function)、[namespace](#namespace) のスコープにおいて、宣言を置くことができる箇所の全てで、BOOST_STATIC_ASSERT を利用できる。次に例を示す。
+
+## <a name="namespace"></a>§namespaceスコープでの使用。(Use at namespace scope)
+
+マクロは、常に真でなければならない前提条件がある場合に、namespace スコープで使うことが出来る。 通常、これはいくつかのプラットホーム依存の条件を意味する。 例えば、我々が **`int`** が少なくとも32ビット以上あり、**`wchar_t`** が符号無しであることを必要としていると想定する。 我々は次のようにして、コンパイル時にこれを検査することができる。
+
+``` cpp
+#include <climits>
+#include <cwchar>
+#include <boost/static_assert.hpp>
+
+namespace my_conditions {
+
+BOOST_STATIC_ASSERT(sizeof(int) * CHAR_BIT >= 32);
+BOOST_STATIC_ASSERT(WCHAR_MIN >= 0);
+
+} // namespace my_conditions
+```
+
+この例での、*my_conditions* namespace の使用に関して、若干の説明が必要だろう。 マクロBOOST_STATIC_ASSERT は目的実現の為に **typedef** 宣言を生成する。ここで、typedef は名前を持たなければならないので、マクロは仮の名に `__LINE__` の値(現在の行番号)を連結して一意の名前を自動的に生成する。 BOOST_STATIC_ASSERTがクラスまたは関数のスコープで使われる場合は、１行にマクロを複数記述しない限りにおいて、BOOST_STATIC_ASSERTの使用によって各々のスコープにおいて一意の名前が生成されることが保証される。 しかしながら、マクロがヘッダにおいて利用されるとき、namespace は複数のヘッダ間に渡ることがありうる。そして、同一の namespace を持つ複数のヘッダの、同じ行においてマクロが使用されたときに、同じ名前をもつ宣言を複数箇所で行うことになるかもしれない。 コンパイラは二重のtypedef宣言を暗黙のうちに無視しなければならないが、しかしながら、多くはそうしないが為に、意図しないエラーを引き起こしてしまう（また、仮に二重宣言を無視するにしても、そのような場合には警告を生成しても良いとなっている）。 よって、あなたがヘッダファイルにおいて、namespace スコープでBOOST_STATIC_ASSERTを使うならば、そのような潜在的な問題を避けるために、そのヘッダに特有の namespace で、BOOST_STATIC_ASSERT を囲まねばならない。
+
+## <a name="function"></a>§関数スコープでの使用（Use at function scope）
+
+マクロは典型的にテンプレート関数内において、テンプレート引数の検査が必要な時に利用される。 我々がiteratorによって捜査対象を指示される algorithm（iterator を受け取るテンプレート関数）を所持しており、それがランダムアクセスiterator を必要とすると想定する。 想定条件に合わない iterator を用いて algorithm が実体化された場合は、最終的にエラーが生成されることになるが、しかし、これは深く入れ子になった先のテンプレートの実体化によって引き起こされたエラーかもしれず、このことにが、ユーザーにとって何がエラーの原因かを特定することが難しくしている。 1つの選択としてはテンプレートのトップのレベルで、iterator の種別のコンパイル時判定を追加することである。もし、条件が合わない場合には、ユーザーにテンプレートが誤用されていることを明らかにするような形でエラーを生成できる。
+
+```cpp
+#include <iterator>
+#include <boost/static_assert.hpp>
+#include <boost/type_traits.hpp>
+
+template <class RandomAccessIterator >
+RandomAccessIterator foo(RandomAccessIterator from, RandomAccessIterator to)
+{
+   // this template can only be used with
+   // random access iterators...
+   // このテンプレートは、ランダムアクセス iterator でのみ利用可能である。
+   typedef typename std::iterator_traits< RandomAccessIterator >::iterator_category cat;
+   BOOST_STATIC_ASSERT((boost::is_convertible<cat, const std::random_access_iterator_tag&>::value));
+   //
+   // detail goes here...
+   // 詳細は、これ以降...
+   return from;
+}
+```
+
+注: assertマクロのまわりの特別な括弧の組は、boost::is_convertible テンプレート中の「,」をプリプロセッサによってマクロ引数分離子として解釈されることを防いでいる。 boost::is_convertible の変換先の型が参照型であるため、若干のコンパイラにおいて型変換がユーザー定義コンストラクタを使用する時に boost::is_convvertible の使用に問題が生じる（いずれにしても、itarator tag クラスが、コピーコンストラクト可能であるという保証がない）
+
+## <a name="class"></a>§クラス・スコープでの使用（Use at class scope）
+
+マクロは典型的にテンプレートクラス内で使用される。 例えば、我々がテンプレート引数に最低でも16bit精度以上で符号無しの整数型を必要とするテンプレートクラスを利用する場合、我々はこの要請次のようにすることで満たすことが出来る：
+
+```cpp
+#include <climits>
+#include <boost/static_assert.hpp>
+
+template <class UnsignedInt>
+class myclass
+{
+private:
+   BOOST_STATIC_ASSERT(sizeof(UnsignedInt) * CHAR_BIT >= 16);
+   BOOST_STATIC_ASSERT(std::numeric_limits<UnsignedInt>::is_specialized
+                        && std::numeric_limits<UnsignedInt>::is_integer
+                        && !std::numeric_limits<UnsignedInt>::is_signed);
+public:
+   /* details here */
+   // 実装の詳細 はここに記述する
+};
+```
+
+## §どのように実現されているか（How it works）
+
+BOOST_STATIC_ASSERTは、次のようにして実現される。 STATIC_ASSERTION_FAILURE クラスが次のように定義されている：
+
+```cpp
+namespace boost{
+
+template <bool> struct STATIC_ASSERTION_FAILURE;
+
+template <> struct STATIC_ASSERTION_FAILURE<true>{};
+
+}
+```
+
+鍵となる点は、未定義式 sizeof(STATIC_ASSERTION_FAILURE<0>) によって引き起こされるエラー・メッセージが多種多様なコンパイラ間で似通った表現である傾向があるということである。 動作原理の残りは BOOST_STATIC_ASSERT が、sizeof式をtypedef中に入れ込む手法である。 ここのマクロの使用は、いくぶん見苦しい。 boostの開発メンバーは、static assert をマクロの使用避けて作成しようとかなりの努力を費やした。しかしながら、それらは何れも成功しなかった。 結論として、static assert を namespace、関数、クラススコープでうまく利用出来るようにするにはマクロの醜さを考慮の外に置くしかないということだった。
+
+## §テストプログラム（Test Programs ）
+
+以下のテストプログラムが、このライブラリと共に提供される：
+
+
+| テスト･プログラム | コンパイル可能か？ | 説明 |
+| - | - | - |
+| [static_assert_test.cpp](http://www.boost.org/doc/libs/1_31_0/libs/static_assert/static_assert_test.cpp) | はい | 使用法の例、および、コンパイラの互換性テストの為にコンパイルされるべきである。 |
+| [static_assert_example_1.cpp](http://www.boost.org/doc/libs/1_31_0/libs/static_assert/static_assert_example_1.cpp) | プラットフォーム依存 | namespace スコープ・テストプログラムがコンパイルできるかは、プラットフォームに依存する。 |
+| [static_assert_example_2.cpp](http://www.boost.org/doc/libs/1_31_0/libs/static_assert/static_assert_example_2.cpp) | はい | 関数スコープ・テストプログラム。 |
+| [static_assert_example_3.cpp](http://www.boost.org/doc/libs/1_31_0/libs/static_assert/static_assert_example_3.cpp) | はい | クラススコープ・テストプログラム。 |
+| [static_assert_test_fail_1.cpp](http://www.boost.org/doc/libs/1_31_0/libs/static_assert/static_assert_test_fail_1.cpp) | いいえ | namespace スコープでの失敗の例 |
+| [static_assert_test_fail_2.cpp](http://www.boost.org/doc/libs/1_31_0/libs/static_assert/static_assert_test_fail_2.cpp) | いいえ | 非テンプレートの関数スコープでの失敗の例 |
+| [static_assert_test_fail_3.cpp](http://www.boost.org/doc/libs/1_31_0/libs/static_assert/static_assert_test_fail_3.cpp) | いいえ | 非テンプレートのクラススコープでの失敗の例 |
+| [static_assert_test_fail_4.cpp](http://www.boost.org/doc/libs/1_31_0/libs/static_assert/static_assert_test_fail_4.cpp) | いいえ | 非テンプレートのクラス・スコープでの失敗の例 |
+| [static_assert_test_fail_5.cpp](http://www.boost.org/doc/libs/1_31_0/libs/static_assert/static_assert_test_fail_5.cpp) | いいえ | テンプレートクラス・スコープでの失敗の例 |
+| [static_assert_test_fail_6.cpp](http://www.boost.org/doc/libs/1_31_0/libs/static_assert/static_assert_test_fail_6.cpp) | いいえ | テンプレートクラスのメンバー関数スコープでの失敗の例 |
+| [static_assert_test_fail_7.cpp](http://www.boost.org/doc/libs/1_31_0/libs/static_assert/static_assert_test_fail_7.cpp) | いいえ | クラス・スコープでの失敗の例 |
+| [static_assert_test_fail_8.cpp](http://www.boost.org/doc/libs/1_31_0/libs/static_assert/static_assert_test_fail_8.cpp) | いいえ | 関数スコープでの失敗の例 |
+| [static_assert_test_fail_9.cpp](http://www.boost.org/doc/libs/1_31_0/libs/static_assert/static_assert_test_fail_9.cpp) | いいえ | 関数スコープでの失敗の例(その２) |
+
+---
+
+Revised 27th Nov 2000
+
+Documentation © Copyright John Maddock 2000. Permission to copy, use, modify, sell and distribute this document is granted provided this copyright notice appears in all copies. This document is provided "as is" without express or implied warranty, and with no claim as to its suitability for any purpose.
+
+Based on contributions by Steve Cleary and John Maddock.
+
+Maintained by [John Maddock](mailto:John_Maddock@compuserve.com), the latest version of this file can be found at [www.boost.org](http://www.boost.org/), and the boost discussion list at [www.yahoogroups.com/list/boost](http://www.yahoogroups.com/list/boost).
+
+---
+
+日本語版第１版 2003年 2月 14日(原文 2002/11/27日版ベース)
+
+Japanese version - based 27th Nov 2000 - Revised 14th Feb 2003
+
+Japanese Translation Copyright (C) 2003 [mikari(Mika.N)](mailto:mikarim@m18.alpha-net.ne.jp).
+
+The project "Boost Japanese Translation" was proposed by [Kohske Takahashi](mailto:kohske@msc.biglobe.ne.jp).
+
+オリジナルドキュメントは、 西暦 2000年 John Maddock によって作成された。
+
+オリジナルの、及びこの著作権表示が全ての複製の中に現れる限り、この文書の複製、利用、変更、販売そして配布を認める。 このドキュメントは「あるがまま」に提供されており、いかなる明示的、暗黙的保証も行わない。 また、いかなる目的に対しても、その利用が適していることを関知しない。
+
+原文は、Steve Cleary と John Maddock の投稿に基づいており、[John Maddock](mailto:John_Maddock@compuserve.com) によって 保守されている。最新版は [www.boost.org](http://www.boost.org/)より得ることが出来る。 また、議論の記録は次の場所で参照できる（[www.yahoogroups.com/list/boost](http://www.yahoogroups.com/list/boost)）


### PR DESCRIPTION
Boost.StaticAssertの翻訳ドキュメントと依存している汎整数定数式のドキュメントを移植。