### PR TITLE
サンプルコードに'\'がないのでコンパイルエラーになる

### DIFF
--- a/tips/dynamic_regex.md
+++ b/tips/dynamic_regex.md
@@ -39,7 +39,7 @@ int main()
 {
     std::string hello = "Hello World!";
 
-    sregex rex = sregex::compile("(\w+) (\w+)!");
+    sregex rex = sregex::compile("(\\w+) (\\w+)!");
     smatch what;
     if (regex_match(hello, what, rex)) {
         std::cout << what[0] << std::endl; // マッチ全体


### PR DESCRIPTION
動的な正規表現のサンプルコードを実行中にコンパイルエラーになるコードを見つけました。

[文字列全体が正規表現にマッチするか調べる](https://boostjp.github.io/tips/dynamic_regex.html#regex-match)にて、毒的にマッチするパターンのコードに '\\' がないようです。

