### PR TITLE
動的な正規表現のサンプルコードに'\'を追加

### DIFF
--- a/tips/dynamic_regex.md
+++ b/tips/dynamic_regex.md
@@ -75,7 +75,7 @@ int main()
 {
     std::string str = "私は1973/5/30の午前7時に生まれた。";
 
-    sregex rex = sregex::compile("(\d{4})/(\d{1,2})/(\d{1,2})");
+    sregex rex = sregex::compile("(\\d{4})/(\\d{1,2})/(\\d{1,2})");
     smatch what;
     if (regex_search(str, what, rex)) {
         std::cout << what[0] << std::endl; // マッチ全体
@@ -121,7 +121,7 @@ int main()
 {
     std::string str = "私は1973/5/30の午前7時に生まれた。";
 
-    sregex date = sregex::compile("\d{4}/\d{1,2}/\d{1,2}");
+    sregex date = sregex::compile("\\d{4}/\\d{1,2}/\\d{1,2}");
     std::string format = "<date>$&</date>";
 
     str = regex_replace(str, date, format);


### PR DESCRIPTION
以下のサンプルコードに`\`を追加し、コンパイルできるように修正しました。

``` cpp
#include <iostream>
#include <boost/xpressive/xpressive.hpp>

using namespace boost::xpressive;

int main()
{
    std::string str = "私は1973/5/30の午前7時に生まれた。";

    sregex rex = sregex::compile("(\d{4})/(\d{1,2})/(\d{1,2})");
    smatch what;
    if (regex_search(str, what, rex)) {
        std::cout << what[0] << std::endl; // マッチ全体
        std::cout << what[1] << std::endl; // 年
        std::cout << what[2] << std::endl; // 月
        std::cout << what[3] << std::endl; // 日
    }
}
```

``` cpp
#include <iostream>
#include <boost/xpressive/xpressive.hpp>

using namespace boost::xpressive;

int main()
{
    std::string str = "私は1973/5/30の午前7時に生まれた。";

    sregex date = sregex::compile("\d{4}/\d{1,2}/\d{1,2}");
    std::string format = "<date>$&</date>";

    str = regex_replace(str, date, format);
    std::cout << str << std::endl;
}
```