### PR TITLE
サイトのビルドを GitHub Actions 化した

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,55 @@
+name: build
+
+on:
+  push:
+    branches:
+      - github-actions
+  schedule:
+    # UTC 表記
+    # 日本時間 23:30
+    - cron: "30 14 * * *"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Register SSH key
+      env:
+        BOOSTJP_GITHUB_IO_SECRETS: ${{ secrets.BOOSTJP_GITHUB_IO_SECRETS }}
+      run: |
+        mkdir -p $HOME/.ssh
+        echo "$BOOSTJP_GITHUB_IO_SECRETS" > $HOME/.ssh/id_ed25519
+        chmod 600 $HOME/.ssh/id_ed25519
+
+    # site_generator
+    - uses: actions/checkout@v2
+      with:
+        repository: cpprefjp/site_generator
+        path: site_generator
+    - run: git submodule update -i
+      working-directory: site_generator
+
+    # boostjp.github.io
+    - uses: actions/checkout@v2
+      with:
+        repository: boostjp/boostjp.github.io
+        path: site_generator/boostjp/boostjp.github.io
+
+    # site
+    - uses: actions/checkout@v2
+      with:
+        repository: boostjp/site
+        path: site_generator/boostjp/site
+        # atom 生成のために全履歴が必要
+        fetch-depth: 0
+    - run: git submodule update -i
+      working-directory: site_generator/boostjp/site
+
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.x
+
+    # あとはスクリプトで頑張る
+    - run: ./boostjp/site/.github/workflows/script/build.sh
+      working-directory: site_generator

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: build
 on:
   push:
     branches:
-      - github-actions
+      - master
   schedule:
     # UTC 表記
     # 日本時間 23:30

--- a/.github/workflows/script/build.sh
+++ b/.github/workflows/script/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# site_generator 直下でこのスクリプトを実行すること
+
+set -ex
+
+# サイトの生成
+pip3 install -r docker/requirements.txt
+python3 run.py settings.boostjp --concurrency=`nproc`
+
+# 生成されたサイトの中身を push
+pushd boostjp/boostjp.github.io
+  # push するために ssh のリモートを追加する
+  git remote add origin2 git@github.com:boostjp/boostjp.github.io.git
+
+  git add ./ --all
+  git config --global user.email "shigemasa7watanabe+boostjp@gmail.com"
+  git config --global user.name "boostjp-autoupdate"
+  git commit -a -m "update automatically"
+  git push origin2 master
+popd


### PR DESCRIPTION
今まで自分が管理してたさくらVPSのサーバを使ってビルドしていましたが、それを GitHub Actions で行うようにしました。

- site の master ブランチへの push か、毎日 23:30 をトリガーにビルドが走ります。
  - デイリーを用意しているのは site_generator が更新された時に反映する用です。
- サイトをビルドした後、boostjp/boostjp.github.io に自動的に push します。
- boostjp.github.io に push するための秘密鍵は GitHub の Secrets に保存していて、公開鍵は boostjp.github.io のデプロイキーとして登録しています。
  - 秘密鍵は手元でも削除したので、もし何かの理由で使えなくなったら登録し直す必要があります。

ref: https://github.com/cpprefjp/site/pull/739