### PR TITLE
メーリングリストページのアーカイブ先を修正した

### DIFF
--- a/mailing-lists.md
+++ b/mailing-lists.md
@@ -13,7 +13,7 @@ Boostの全般的な話題。ユーザー寄りだが開発者寄りの話題も
 
 アーカイブ：
 
-- [Boost Mailing Lists - boost.user](https://www.boost.org/community/groups.html#users)
+- [Boost-users Archives](https://lists.boost.org/boost-users/)
 - [Google Group](http://groups.google.com/group/boost-list/topics)
 
 ## Boost開発者ML
@@ -103,7 +103,7 @@ Boost.Pythonやluabindなどの、言語バインディング関係のML。
 
 アーカイブ：
 
-- [spirit-devel](https://sourceforge.net/p/spirit/mailman/spirit-devel/)
+- [spirit-general](https://sourceforge.net/p/spirit/mailman/spirit-general/)
 
 
 **開発者ML**
@@ -114,7 +114,7 @@ Boost.Pythonやluabindなどの、言語バインディング関係のML。
 
 アーカイブ：
 
-- [Boost Mailing Lists - parsers.spirit.devel](https://www.boost.org/community/groups.html#spirit)
+- [spirit-devel](https://sourceforge.net/p/spirit/mailman/spirit-devel/)
 
 
 ## BoostドキュメンテーションシステムML

--- a/mailing-lists.md
+++ b/mailing-lists.md
@@ -13,7 +13,7 @@ Boostの全般的な話題。ユーザー寄りだが開発者寄りの話題も
 
 アーカイブ：
 
-- [Gmane](http://thread.gmane.org/gmane.comp.lib.boost.user)
+- [Boost Mailing Lists - boost.user](https://www.boost.org/community/groups.html#users)
 - [Google Group](http://groups.google.com/group/boost-list/topics)
 
 ## Boost開発者ML
@@ -25,7 +25,7 @@ Boostの開発者ML。新たなライブラリの提案、レビュー、運用�
 
 アーカイブ：
 
-- [Gmane](http://thread.gmane.org/gmane.comp.lib.boost.devel/)
+- [Boost Mailing Lists - boost.devel](https://www.boost.org/community/groups.html#main)
 
 
 ## アナウンス
@@ -45,7 +45,7 @@ Boost.Build, bjamなどのML。
 
 アーカイブ：
 
-- [Gmane](http://thread.gmane.org/gmane.comp.lib.boost.build)
+- [Boost Mailing Lists - boost.build](https://www.boost.org/community/groups.html#jamboost)
 
 ## Boost CMake ML
 CMakeのML。
@@ -56,7 +56,8 @@ CMakeのML。
 
 アーカイブ：
 
-- [Gmane](http://thread.gmane.org/gmane.comp.lib.boost.cmake)
+- [Boost Mailing Lists - boost.cmake](https://www.boost.org/community/groups.html#cmake)
+
 
 ## Boost Community Maintenance ML
 個人のメンテナではなく、コミュニティによってメンテナンスしていくライブラリのML。
@@ -75,7 +76,7 @@ Boost.Python関係のML。
 
 アーカイブ：
 
-- [Gmane](http://thread.gmane.org/gmane.comp.python.c%2b%2b)
+- [Boost Mailing Lists - boost.python](https://www.boost.org/community/groups.html#cplussig)
 
 
 ## 言語バインディングML
@@ -87,7 +88,7 @@ Boost.Pythonやluabindなどの、言語バインディング関係のML。
 
 アーカイブ：
 
-- [Gmane](http://thread.gmane.org/gmane.comp.lib.boost.langbinding)
+- [Boost Mailing Lists - boost.langbinding](https://www.boost.org/community/groups.html#langbinding)
 
 
 ## Boost Spirit ML
@@ -102,7 +103,8 @@ Boost.Pythonやluabindなどの、言語バインディング関係のML。
 
 アーカイブ：
 
-- [Gmane](http://thread.gmane.org/gmane.comp.parsers.spirit.general)
+- [Boost Mailing Lists - parsers.spirit.general](https://www.boost.org/community/groups.html#spirit)
+
 
 **開発者ML**
 
@@ -111,7 +113,7 @@ Boost.Pythonやluabindなどの、言語バインディング関係のML。
 - [https://lists.sourceforge.net/lists/listinfo/spirit-devel](https://lists.sourceforge.net/lists/listinfo/spirit-devel)
 
 アーカイブ：
-- [Gmane](http://thread.gmane.org/gmane.comp.parsers.spirit.devel)
+- [Boost Mailing Lists - parsers.spirit.devel](https://www.boost.org/community/groups.html#spirit)
 
 
 ## BoostドキュメンテーションシステムML
@@ -124,7 +126,7 @@ BoostBookやQuickBookのML。
 
 アーカイブ：
 
-- [Gmane](http://thread.gmane.org/gmane.comp.lib.boost.documentation)
+- [Boost Mailing Lists - boost.documentation](https://www.boost.org/community/groups.html#boostdocs)
 
 ## Boost Thread ML
 Boost.Threadの開発者ML。
@@ -135,7 +137,7 @@ Boost.Threadの開発者ML。
 
 アーカイブ：
 
-- [Gmane](http://thread.gmane.org/gmane.comp.lib.boost.threads.devel)
+- [Boost Mailing Lists - boost.threads.devel](https://www.boost.org/community/groups.html#thread)
 
 
 ## Boost Test ML
@@ -156,7 +158,7 @@ Boostのレギュレッションテストを走らせたり、Boost.Testをい�
 
 アーカイブ：
 
-- [Gmane](http://thread.gmane.org/gmane.comp.lib.boost.ublas)
+- [Boost Mailing Lists - boost.ublas](https://www.boost.org/community/groups.html#ublas)
 
 
 ## Boost Proto ML
@@ -177,7 +179,6 @@ EDSL(Embedded Domain Specific Language)を定義するためのライブラリ�
 アーカイブ：
 
 - [SourceForge](http://sourceforge.net/mail/?group_id=122478)
-- [Gmane](http://thread.gmane.org/gmane.comp.lib.boost.asio.user)
 
 
 ## Boost Geometry ML

--- a/mailing-lists.md
+++ b/mailing-lists.md
@@ -25,7 +25,7 @@ Boostの開発者ML。新たなライブラリの提案、レビュー、運用�
 
 アーカイブ：
 
-- [Boost Mailing Lists - boost.devel](https://www.boost.org/community/groups.html#main)
+- [Boost Archives](https://lists.boost.org/Archives/boost/)
 
 
 ## アナウンス
@@ -45,7 +45,7 @@ Boost.Build, bjamなどのML。
 
 アーカイブ：
 
-- [Boost Mailing Lists - boost.build](https://www.boost.org/community/groups.html#jamboost)
+- [Boost-Build Archives](https://lists.boost.org/boost-build/)
 
 ## Boost CMake ML
 CMakeのML。
@@ -56,7 +56,7 @@ CMakeのML。
 
 アーカイブ：
 
-- [Boost Mailing Lists - boost.cmake](https://www.boost.org/community/groups.html#cmake)
+- [Boost-cmake](https://lists.boost.org/boost-cmake/)
 
 
 ## Boost Community Maintenance ML
@@ -76,7 +76,7 @@ Boost.Python関係のML。
 
 アーカイブ：
 
-- [Boost Mailing Lists - boost.python](https://www.boost.org/community/groups.html#cplussig)
+- [Cplusplus-sig](https://mail.python.org/pipermail/cplusplus-sig/)
 
 
 ## 言語バインディングML
@@ -103,7 +103,7 @@ Boost.Pythonやluabindなどの、言語バインディング関係のML。
 
 アーカイブ：
 
-- [Boost Mailing Lists - parsers.spirit.general](https://www.boost.org/community/groups.html#spirit)
+- [spirit-devel](https://sourceforge.net/p/spirit/mailman/spirit-devel/)
 
 
 **開発者ML**
@@ -113,6 +113,7 @@ Boost.Pythonやluabindなどの、言語バインディング関係のML。
 - [https://lists.sourceforge.net/lists/listinfo/spirit-devel](https://lists.sourceforge.net/lists/listinfo/spirit-devel)
 
 アーカイブ：
+
 - [Boost Mailing Lists - parsers.spirit.devel](https://www.boost.org/community/groups.html#spirit)
 
 
@@ -126,7 +127,7 @@ BoostBookやQuickBookのML。
 
 アーカイブ：
 
-- [Boost Mailing Lists - boost.documentation](https://www.boost.org/community/groups.html#boostdocs)
+- [Boost-docs Archives](https://lists.boost.org/boost-docs/)
 
 ## Boost Thread ML
 Boost.Threadの開発者ML。
@@ -137,7 +138,7 @@ Boost.Threadの開発者ML。
 
 アーカイブ：
 
-- [Boost Mailing Lists - boost.threads.devel](https://www.boost.org/community/groups.html#thread)
+- [Threads-Devel Archives](https://lists.boost.org/threads-devel/)
 
 
 ## Boost Test ML
@@ -158,7 +159,7 @@ Boostのレギュレッションテストを走らせたり、Boost.Testをい�
 
 アーカイブ：
 
-- [Boost Mailing Lists - boost.ublas](https://www.boost.org/community/groups.html#ublas)
+- [ublas Archives](https://lists.boost.org/ublas/)
 
 
 ## Boost Proto ML


### PR DESCRIPTION
## 修正内容

- 旧Gmaneのリンクを [https://www.boost.org/community/groups.html](https://www.boost.org/community/groups.html) の対応するアーカイブに修正しました
- 言語バインディングMLはアーカイブ先が見つからなかったので、本家のページ内リンクにしています
- Boost AsioユーザーMLについては、SourceForgeのアーカイブが既にあったのでGmaneリンクを削除しました

## 確認したこと
各MLに対応するアーカイブリンク先が存在することを確認しました

## issue link

#426

## レビュワーに確認して頂きたい点

変更したリンク先で良いかどうかを見ていただきたいです
どうぞ、よろしくお願いします