### PR TITLE
「編集に際してのその他の方針、ガイドライン」の項を追加

### DIFF
--- a/editors_doc/start_editing.md
+++ b/editors_doc/start_editing.md
@@ -42,3 +42,5 @@ Markdownの記述方法をわかりやすく解説してくれているWebサイ
 Markdown形式では、htmlのタグも併用できますが、boostjpサイトでは積極的にはhtmlタグを使用しない方針です。できるだけ、Markdown形式でできる範囲内で解決するようにしてください。
 
 
+## 編集に際してのその他の方針、ガイドライン
+編集に際してのその他の方針については、cpprefjpの[編集方針](https://cpprefjp.github.io/edit_policy.html)及び[はじめてのコントリビュート](https://cpprefjp.github.io/start_editing.html)をご覧ください。


### PR DESCRIPTION
「boostjpを編集するには」のページに、cpprefjpの「編集方針」及び「はじめてのコントリビュート」への誘導を追加しました。

コミュニティ全体の方針に関わるところであるため、確認としてPRとしました。

Closed #569 