### PR TITLE
Boost逆引きリファレンスに、類似機能を説明したcpprefjpへのリンクを追加する

### DIFF
--- a/tips/foreach.md
+++ b/tips/foreach.md
@@ -10,6 +10,7 @@
 - [逆順にループする](#reverse-iteration)
 - [配列に対して使用する](#apply-multi-array)
 - [C++11 範囲`for`文との違い](#difference-cpp11-range-for)
+- [C++の国際標準規格上の類似する機能](#cpp-standard)
 
 
 ## <a id="boost-foreach-macro" href="#boost-foreach-macro">BOOST_FOREACHマクロ</a>
@@ -379,3 +380,10 @@ for (int x : v) {}
 
 `BOOST_FOREACH`マクロには、このような制限はないため、定義済みの変数を要素として使用できる。
 
+## <a id="cpp-standard" href="#cpp-standard">C++の国際標準規格上の類似する機能</a>
+- [`BOOST_FOREACH`マクロ](#boost-foreach-macro)
+  - [`std::for_each`](https://cpprefjp.github.io/reference/algorithm/for_each.html)
+- [逆順にループする](#reverse-iteration)
+  - [`std::ranges::reverse_view`、`std::ranges::views::reverse`](https://cpprefjp.github.io/reference/ranges/reverse_view.html)
+- [C++11 範囲`for`文との違い](#difference-cpp11-range-for)
+  - [範囲for文](https://cpprefjp.github.io/lang/cpp11/range_based_for.html)

--- a/tips/hashmap.md
+++ b/tips/hashmap.md
@@ -8,6 +8,7 @@
 - [基本的な使い方](#basic-usage)
 - [ユーザー定義型をキーにする(オーバーロード)](#user-defined-type-as-key-using-overload)
 - [ユーザー定義型をキーにする(ポリシー)](#user-defined-type-as-key-using-policy)
+- [C++の国際標準規格上の類似する機能](#cpp-standard)
 
 
 ## <a id="basic-usage" href="#basic-usage">基本的な使い方</a>
@@ -172,3 +173,6 @@ int main()
 ```
 
 
+## <a id="cpp-standard" href="#cpp-standard">C++の国際標準規格上の類似する機能</a>
+- [`std::unordered_map`](https://cpprefjp.github.io/reference/unordered_map/unordered_map.html)
+- [`std::unordered_set`](https://cpprefjp.github.io/reference/unordered_set/unordered_set.html)

--- a/tips/optional.md
+++ b/tips/optional.md
@@ -6,6 +6,7 @@
 - [関数の失敗値と成功値](#fail-value)
 - [無効値がありえることを仕様ではなく型で示す](#type-as-nullary-value)
 - [`if`文の条件式で定義した変数に格納する](#store-value-in-if-expr)
+- [C++の国際標準規格上の類似する機能](#cpp-standard)
 
 
 ## <a id="fail-value" href="#fail-value">関数の失敗値と成功値</a>
@@ -138,3 +139,6 @@ if (boost::optional<int> p = get_vector()) {
 }
 ```
 
+## <a id="cpp-standard" href="#cpp-standard">C++の国際標準規格上の類似する機能</a>
+- [`std::optional`](https://cpprefjp.github.io/reference/optional/optional.html)
+- [`std::expected`](https://cpprefjp.github.io/reference/expected/expected.html)

--- a/tips/static_assert.md
+++ b/tips/static_assert.md
@@ -8,6 +8,7 @@
 ## インデックス
 - [関数にコンパイル時アサートを付ける](#function)
 - [クラスにコンパイル時アサートを付ける](#class)
+- [C++の国際標準規格上の類似する機能](#cpp-standard)
 
 
 ## <a id="function" href="#function">関数にコンパイル時アサートを付ける</a>
@@ -55,3 +56,5 @@ int main()
 }
 ```
 
+## <a id="cpp-standard" href="#cpp-standard">C++の国際標準規格上の類似する機能</a>
+- [コンパイル時アサート](https://cpprefjp.github.io/lang/cpp11/static_assert.html)

--- a/tips/variant.md
+++ b/tips/variant.md
@@ -8,6 +8,7 @@
 - [格納されている値を取り出す](#get-value)
 - [値をクリアする](#clear)
 - [variantを再帰的にする](#recursive-variant)
+- [C++の国際標準規格上の類似する機能](#cpp-standard)
 
 
 ## <a id="basic-usage" href="#basic-usage">基本的な使い方</a>
@@ -332,5 +333,7 @@ auto main() -> int
 ]
 ```
 
+## <a id="cpp-standard" href="#cpp-standard">C++の国際標準規格上の類似する機能</a>
+- [std::variant](https://cpprefjp.github.io/reference/variant/variant.html)
 
 documentated boost version is 1.52.0


### PR DESCRIPTION
#568 でお話ししたように、一部のページに類似する標準機能へのリンクを追加してみました。
この形式で大丈夫であれば、今後はmasterへ直コミットでもよいかなと思っているのですが、いかがでしょうか。



